### PR TITLE
Formatting shortcut on mac is `Shift + Alt + K`

### DIFF
--- a/SHORTCUTS-MAC.md
+++ b/SHORTCUTS-MAC.md
@@ -78,7 +78,7 @@
 | Command | Action |
 | --- | --- |
 | `Cmd + space` | Trigger suggestions |
-| `Cmd + K Cmd + F` | Format selection |
+| `Shift + Alt + F`  | Format selection |
 | `Alt + F12` | Peek definition |
 | `Cmd + K F12` | Navigate to definition |
 | Hold `Cmd` then hover over symbol | Mini peek definition |


### PR DESCRIPTION
Both in the [video on hints](https://youtu.be/0Er_idXv3js?t=176) as well as getting the formatting to work in Safari and Chrome the shortcut for formatting is not Cmd + K or Cmd + F it is `Shift + Alt + F`