### PR TITLE
Correct Mac shortcut for "Trigger suggestions"

### DIFF
--- a/SHORTCUTS-MAC.md
+++ b/SHORTCUTS-MAC.md
@@ -77,7 +77,7 @@
 #### <a name="rich-text">Rich text editor</a>
 | Command | Action |
 | --- | --- |
-| `Cmd + space` | Trigger suggestions |
+| `Ctrl + Space` | Trigger suggestions |
 | `Shift + Alt + F`  | Format selection |
 | `Alt + F12` | Peek definition |
 | `Cmd + K F12` | Navigate to definition |


### PR DESCRIPTION
This is just a simple correction. On Mac, Ctrl+Space is the correct shortcut for "Trigger suggestions" in Scrimba as in VS Code. (Cmd+Space opens Spotlight search.)